### PR TITLE
Higher accessibility through aria attributes to menu buttons

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -54,6 +54,7 @@ body {
 	padding: 10px 16px;
 	background: rgba(255, 255, 255, 0.6);
 	font-weight: bold;
+	border: none;
 }
 
 #menu ul > ul {
@@ -241,5 +242,7 @@ video {
 
 	#content_top #mobile_nav_icon {
 		display: inline;
+		font-size: 1.2em;
+		color: #0645ad;
 	}
 }

--- a/public/js/PineDocs.js
+++ b/public/js/PineDocs.js
@@ -333,12 +333,14 @@ $(function() {
 
 	PineDocs.prototype.show_mobile_menu = function() {
 		var self = this
+		self.elements.mobile_nav_icon.attr('aria-expanded', 'true');
 		self.elements.menu_wrapper.hide().removeClass('hidden').slideDown('fast')
 	}
 
 
 	PineDocs.prototype.hide_mobile_menu = function() {
 		var self = this
+        self.elements.mobile_nav_icon.attr('aria-expanded', 'false');
 		self.elements.menu_wrapper.addClass('hidden')
 	}
 

--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -15,8 +15,6 @@
 		<div id="main" class="container">
 
 				<div id="menu_wrapper" class="">
-					<div id="menu_close">X</div>
-
 					<div id="menu" class="navbar-default">
 						<div id="menu_top">
 							<a href="."><img id="logo" src="<?= PineDocs::$config->logo ?>" /></a>
@@ -30,11 +28,12 @@
 							</footer>
 						<?php endif ?>
 					</div>
-				</div>
+                    <button aria-label="Close navigation" type="button" id="menu_close">X</button>
+                </div>
 
 				<div id="content_wrapper">
 					<div id="content_top">
-						<a id="mobile_nav_icon"><i class="fa fa-bars" aria-hidden="true"></i></a>
+						<button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="menu_wrapper" aria-label="Navigation" id="mobile_nav_icon"><i class="fa fa-bars" aria-hidden="true"></i></button>
 						<span id="content_path"></span>
 					</div>
 					<div id="loading"></div>


### PR DESCRIPTION
Hello, @xy2z!

When I opened the menu on mobile, I had an empty tab. It's cause by event listener on every body link. 
PineDocs.js:159

It was broken by #15 btw. :)

I've made some changes to basic html template, so it's now more screenreader-friendly and easy accessible via tab. 
