### PR TITLE
Add support of cyrillic filenames

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -30,14 +30,14 @@
 	// Get file from ajax call.
 	if (isset($param_action) && $param_action === 'get_file_data' && isset($param_relative_path)) {
 		header('Content-Type: application/json');
-		$relative_path = utf8_decode($param_relative_path);
+		$relative_path = urldecode($param_relative_path);
 		$PineDocsFile = new PineDocsFile(xy_format_path(PineDocs::$config->content_dir . $relative_path));
 		echo json_encode($PineDocsFile->get_data(), JSON_PRETTY_PRINT);
 		exit;
 	}
 
     if (isset($param_action) && $param_action === 'download' && isset($param_relative_path)) {
-        $relative_path = utf8_decode($param_relative_path);
+        $relative_path = urldecode($param_relative_path);
 
         $PineDocsFile = new PineDocsFile(xy_format_path(PineDocs::$config->content_dir . $relative_path));
         $quoted_name = sprintf('"%s"', addcslashes($PineDocsFile->basename, '"\\'));

--- a/public/js/PineDocs.js
+++ b/public/js/PineDocs.js
@@ -51,10 +51,10 @@ $(function() {
 		// Autoload file from URL anchor tag.
 		if (window.location.hash.length >= 2) {
 			// Check if file exists.
-			var file = $('a.link_file[href="' + window.location.hash + '"]')
+			var file = $('a.link_file[href="' + decodeURIComponent(window.location.hash) + '"]')
 			if (file.length) {
 				// File exists
-				$('a.link_file[href="' + window.location.hash + '"]').click()
+				$('a.link_file[href="' + decodeURIComponent(window.location.hash) + '"]').click()
 			} else {
 				// File does not exist.
 				self.render_hidden_file(window.location.hash.substr(1));
@@ -471,7 +471,7 @@ $(function() {
 			self.render_file(response)
 			$('.active').removeClass('active')
 		}).fail(function(response) {
-			self.render_error_message('Error: could not load file: <u>' + path + '</u><br />File not found.')
+			self.render_error_message('Error: could not load file: <u>' + decodeURIComponent(path) + '</u><br />File not found.')
 		});
 	}
 

--- a/src/PineDocsFile.php
+++ b/src/PineDocsFile.php
@@ -28,7 +28,7 @@
 			}
 
 			$this->full_path = $full_path;
-			$this->relative_path = utf8_encode(str_replace(PineDocs::$config->content_dir, '', $this->full_path));
+			$this->relative_path = mb_convert_encoding(str_replace(PineDocs::$config->content_dir, '', $this->full_path), "UTF-8");
 			$this->basename = $this->get_basename();
 			$this->pathinfo = pathinfo($this->full_path);
 			$this->filesize = filesize($this->full_path);
@@ -96,12 +96,12 @@
 
 
 		private function get_basename() {
-			if (PineDocs::$config->show_file_extension) {
-				return utf8_encode(basename($this->full_path));
-			} else {
-				$basename = utf8_encode(pathinfo($this->full_path, PATHINFO_FILENAME));
-			}
+			$path_arr = array_values(preg_split('/\//', $this->full_path));
+			$basename = end($path_arr);
 
+			if (!PineDocs::$config->show_file_extension) {
+				$basename = array_values(preg_split('/\./', $basename))[0];
+			}
 			return $basename;
 		}
 


### PR DESCRIPTION
Here is my try to add cyrillic filenames support to PineDocs.
I replaced `basename` and `pathinfo` with `preg_split`, since they does not works properly with real utf-8 which appears as loosed basename.
And utf8_decode was replaced to escape  `Ð¿ÑÐ¾Ð±ÐµÐ»Ð°.md` symbols, since as I found in template, that we tell browser, that encoding is utf8. But php docs says that `This function converts the string data from the UTF-8 encoding to ISO-8859-1.`

Original:
![image](https://user-images.githubusercontent.com/17022100/94715914-c4472600-0356-11eb-9901-ad4c0b229b98.png)
Fixed:
![image](https://user-images.githubusercontent.com/17022100/94716563-b47c1180-0357-11eb-9ac8-5bc8767c17fc.png)

Also, I'm not php coder, so sorry in advance.
Cheers!