### PR TITLE
Entrypoint content folder exists check changed to -d flag for folders

### DIFF
--- a/docker/usr/bin/entrypoint
+++ b/docker/usr/bin/entrypoint
@@ -8,7 +8,7 @@ if [ ! -f /data/pinedocs/config/config.yaml ]; then
 fi
 
 # Content
-if [ ! -f /data/pinedocs/files ]; then
+if [ ! -d /data/pinedocs/files ]; then
         mkdir -p /data/pinedocs/files
         cp -a /app/pinedocs/content/. /data/pinedocs/files
         echo 'Created content directory.'


### PR DESCRIPTION
Flag for folder exists check changed to -d, otherwise existing files will always be overwritten