### PR TITLE
Support for larger PDF.

### DIFF
--- a/public/js/PineDocs.js
+++ b/public/js/PineDocs.js
@@ -112,7 +112,14 @@ $(function() {
 			var svg = $('<img>').attr('src', 'data:image/svg+xml;base64,' + data.content)
 			self.elements.file_content.append(svg)
 		} else if (data.type == 'pdf') {
-			var pdf = $('<embed>').attr('src', 'data:application/pdf;base64,' + data.content)
+			// PDF.
+			var binary = atob(data.content)
+			var bytes = new Uint8Array(binary.length)
+			for (var i = 0; i < binary.length; i++) {
+				bytes[i] = binary.charCodeAt(i)
+			}
+
+			var pdf = $('<embed>').attr('src', window.URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' })))
 			pdf.attr('width', '100%')
 			pdf.attr('height', '100%')
 			self.elements.file_content.append(pdf)


### PR DESCRIPTION
I realized that [my implementation of PDFs with `base64`](https://github.com/xy2z/PineDocs/pull/194) was not good because files are often too big, so I used `blob` instead.

There is an encoding of the file in `base64` and then a decoding right after, if I don't do that somehow the file is not recovered...