### PR TITLE
Add menu background on mobile view in simplistic color-schemes

### DIFF
--- a/public/color-schemes/simplistic-dark.css
+++ b/public/color-schemes/simplistic-dark.css
@@ -16,6 +16,7 @@ body {
 	border-right: 1px solid #111;
 }
 #menu {
+	background: #222;
 }
 
 #menu ul {

--- a/public/color-schemes/simplistic.css
+++ b/public/color-schemes/simplistic.css
@@ -17,6 +17,7 @@ body {
 	border-right: 1px solid #ddd;
 }
 #menu {
+	background: #fff;
 }
 
 #menu ul {


### PR DESCRIPTION
Without it the menu is unreadable on mobile

| Before | After
| :-------: | :-:
| ![image](https://user-images.githubusercontent.com/29067904/184357946-1fd18c0a-b800-42de-8add-537d85fa4261.png) | ![image](https://user-images.githubusercontent.com/29067904/184357986-ed387e6a-fd5d-4f84-b2d2-ad0516ad4e94.png)